### PR TITLE
Use latest ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.9'
         os:
           - ubuntu-latest
         arch:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.6'
+          version: '1.9'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         version:
           - '1.6'
         os:
-          - ubuntu-18.04
+          - ubuntu-latest
         arch:
           - x64
     steps:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,6 @@ makedocs(;
     repo="https://github.com/gridap/GridapMakie.jl/blob/{commit}{path}#L{line}",
     sitename="GridapMakie.jl",
     authors="The GridapMakie project contributors",
-    assets=String[],
 )
 
 deploydocs(;


### PR DESCRIPTION
It seems that the cicd isn't running anymore because github doesn't support `ubuntu-18.04` anymore.
Using `ubuntu-latest` instead should make it run again (see discussion in #69)