### PR TITLE
Compatibility with Makie 0.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,13 +13,13 @@ Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [compat]
-CairoMakie = "0.5, 0.6, 0.8"
+CairoMakie = "0.5, 0.6, 0.8,0.11"
 FileIO = "1"
-FillArrays = "0.11, 0.12, 0.13"
-GLMakie = "0.3, 0.4, 0.6"
+FillArrays = "1"
+GLMakie = "0.3, 0.4, 0.6, 0.9"
 GeometryBasics = "0.3, 0.4"
 Gridap = "0.16, 0.17"
-Makie = "0.13, 0.15, 0.17"
+Makie = "0.13, 0.15, 0.17, 0.20"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -13,13 +13,13 @@ Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [compat]
-CairoMakie = "0.5, 0.6, 0.8,0.11"
+CairoMakie = "0.5, 0.6, 0.8,0.11,0.12"
 FileIO = "1"
 FillArrays = "1"
-GLMakie = "0.3, 0.4, 0.6, 0.9"
+GLMakie = "0.3, 0.4, 0.6, 0.9,0.10"
 GeometryBasics = "0.3, 0.4"
-Gridap = "0.16, 0.17"
-Makie = "0.13, 0.15, 0.17, 0.20"
+Gridap = "0.16, 0.17,0.18"
+Makie = "0.13, 0.15, 0.17, 0.20,0.21"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Alberto F. Martín <alberto.f.martin@anu.edu.au>","Eric Neiva <eneiv
 version = "0.1.2"
 
 [deps]
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
@@ -13,13 +12,12 @@ Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [compat]
-CairoMakie = "0.5, 0.6, 0.8,0.11,0.12"
 FileIO = "1"
 FillArrays = "1"
-GLMakie = "0.3, 0.4, 0.6, 0.9,0.10"
+GLMakie = "0.10"
 GeometryBasics = "0.3, 0.4"
 Gridap = "0.16, 0.17,0.18"
-Makie = "0.13, 0.15, 0.17, 0.20,0.21"
+Makie = "0.21"
 julia = "1.6"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Therefore, we may as well visualize such mesh
 model = DiscreteModelFromFile("models/model.json")
 Ω = Triangulation(model)
 ∂Ω = BoundaryTriangulation(model)
-fig = plot(Ω,axis=(type=Makie.Axis3,aspect=:data))
+fig = plot(Ω)
 wireframe!(∂Ω, color=:black)
 save("images/3d_Fig1.png", fig)
 ````
@@ -146,7 +146,7 @@ save("images/3d_Fig1.png", fig)
 
 ````julia
 v(x) = sin(π*(x[1]+x[2]+x[3]))
-fig, ax, plt = plot(Ω, v,axis=(type=Makie.Axis3,aspect=:data))
+fig, ax, plt = plot(Ω, v)
 Colorbar(fig[1,2], plt)
 save("images/3d_Fig2.png", fig)
 ````
@@ -159,7 +159,7 @@ we can even plot functions in certain subdomains, e.g.
 
 ````julia
 Γ = BoundaryTriangulation(model, tags=["square", "triangle", "circle"])
-fig = plot(Γ, v, colormap=:rainbow,axis=(type=Makie.Axis3,aspect=:data))
+fig = plot(Γ, v, colormap=:rainbow)
 wireframe!(∂Ω, linewidth=0.5, color=:gray)
 save("images/3d_Fig3.png", fig)
 ````
@@ -178,7 +178,7 @@ t = Observable(0.0)
 u = lift(t) do t
     x->sin(π*(x[1]+x[2]+x[3]))*cos(π*t)
 end
-fig = plot(Ω, u, colormap=:rainbow, colorrange=(-1,1),axis=(type=Makie.Axis3,aspect=:data))
+fig = plot(Ω, u, colormap=:rainbow, colorrange=(-1,1))
 wireframe!(∂Ω, color=:black, linewidth=0.5)
 framerate = 30
 timestamps = range(0, 2, step=1/framerate)
@@ -194,4 +194,3 @@ end
 ---
 
 *This page was generated using [Literate.jl](https://github.com/fredrikekre/Literate.jl).*
-

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Therefore, we may as well visualize such mesh
 model = DiscreteModelFromFile("models/model.json")
 Ω = Triangulation(model)
 ∂Ω = BoundaryTriangulation(model)
-fig = plot(Ω, shading=true)
+fig = plot(Ω,axis=(type=Makie.Axis3,aspect=:data))
 wireframe!(∂Ω, color=:black)
 save("images/3d_Fig1.png", fig)
 ````
@@ -146,7 +146,7 @@ save("images/3d_Fig1.png", fig)
 
 ````julia
 v(x) = sin(π*(x[1]+x[2]+x[3]))
-fig, ax, plt = plot(Ω, v, shading=true)
+fig, ax, plt = plot(Ω, v,axis=(type=Makie.Axis3,aspect=:data))
 Colorbar(fig[1,2], plt)
 save("images/3d_Fig2.png", fig)
 ````
@@ -159,7 +159,7 @@ we can even plot functions in certain subdomains, e.g.
 
 ````julia
 Γ = BoundaryTriangulation(model, tags=["square", "triangle", "circle"])
-fig = plot(Γ, v, colormap=:rainbow, shading=true)
+fig = plot(Γ, v, colormap=:rainbow,axis=(type=Makie.Axis3,aspect=:data))
 wireframe!(∂Ω, linewidth=0.5, color=:gray)
 save("images/3d_Fig3.png", fig)
 ````
@@ -178,7 +178,7 @@ t = Observable(0.0)
 u = lift(t) do t
     x->sin(π*(x[1]+x[2]+x[3]))*cos(π*t)
 end
-fig = plot(Ω, u, colormap=:rainbow, shading=true, colorrange=(-1,1))
+fig = plot(Ω, u, colormap=:rainbow, colorrange=(-1,1),axis=(type=Makie.Axis3,aspect=:data))
 wireframe!(∂Ω, color=:black, linewidth=0.5)
 framerate = 30
 timestamps = range(0, 2, step=1/framerate)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -110,7 +110,9 @@ end
 
 # Set default plottype as mesh if argument is type Triangulation, i.e., mesh(Ω) == plot(Ω).
 Makie.plottype(::Triangulation) = PlotGridMesh
+Makie.args_preferred_axis(t::Triangulation)= num_point_dims(t)<=2 ? Makie.Axis : Makie.LScene
 Makie.plottype(::PlotGrid) = PlotGridMesh
+Makie.args_preferred_axis(pg::PlotGrid)= num_point_dims(pg.Grid)<=2 ? Makie.Axis : Makie.LScene
 
 @Makie.recipe(MeshField) do scene
     merge!(
@@ -153,7 +155,7 @@ function Makie.plot!(p::MeshField{<:Tuple{CellField}})
 end
 
 Makie.plottype(::CellField) = MeshField
-
+Makie.args_preferred_axis(c::CellField)= num_point_dims(get_triangulation(c))<=2 ? Makie.Axis : Makie.LScene
 
 function Makie.point_iterator(pg::PlotGrid)
     UnstructuredGrid(pg.grid) |> to_dg_points

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -90,8 +90,7 @@ function Makie.convert_arguments(::Type{<:Makie.Wireframe}, pg::PlotGrid)
     println("convert1")
     grid = get_grid(pg)
     mesh = to_plot_mesh(grid)
-    #(mesh, )
-    mesh
+    (mesh, )
 end
 
 function Makie.convert_arguments(::Type{<:Makie.Scatter}, pg::PlotGrid)
@@ -105,7 +104,9 @@ end
 function Makie.convert_arguments(::Type{<:Makie.Mesh}, trian::Triangulation)
     println("convert3")
     grid = to_grid(trian)
-    (PlotGrid(grid), )
+     #(PlotGrid(grid), )
+    mesh = to_plot_mesh(grid)
+    (mesh, )
 end
 
 function Makie.convert_arguments(t::Type{<:Union{Makie.Wireframe, Makie.Scatter}}, trian::Triangulation)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -87,6 +87,7 @@ end
 
 # No need to create discontinuous meshes for wireframe and scatter.
 function Makie.convert_arguments(::Type{<:Makie.Wireframe}, pg::PlotGrid)
+    println("convert1")
     grid = get_grid(pg)
     mesh = to_plot_mesh(grid)
     #(mesh, )
@@ -94,6 +95,7 @@ function Makie.convert_arguments(::Type{<:Makie.Wireframe}, pg::PlotGrid)
 end
 
 function Makie.convert_arguments(::Type{<:Makie.Scatter}, pg::PlotGrid)
+    println("convert2")
     grid = get_grid(pg)
     node_coords = get_node_coordinates(grid)
     x = map(to_point, node_coords)
@@ -101,11 +103,13 @@ function Makie.convert_arguments(::Type{<:Makie.Scatter}, pg::PlotGrid)
 end
 
 function Makie.convert_arguments(::Type{<:Makie.Mesh}, trian::Triangulation)
+    println("convert3")
     grid = to_grid(trian)
     (PlotGrid(grid), )
 end
 
 function Makie.convert_arguments(t::Type{<:Union{Makie.Wireframe, Makie.Scatter}}, trian::Triangulation)
+    println("convert4")
     grid = to_grid(trian)
     Makie.convert_arguments(t, PlotGrid(grid))
 end
@@ -125,6 +129,7 @@ end
 # of p (this is just to draw colorbars). Another way would be using $ Colorbar(fig[1,2], plt.plots[1]), but quite less
 # appealing from the point of view of the user.
 function Makie.plot!(p::MeshField{<:Tuple{Triangulation, Any}})
+    println("plot1")
     trian, uh = p[1:2]
     grid_and_data = Makie.lift(to_grid, trian, uh)
     pg = Makie.lift(i->PlotGrid(i[1]), grid_and_data)
@@ -140,6 +145,7 @@ end
 Makie.plottype(::Triangulation, ::Any) = MeshField
 
 function Makie.plot!(p::MeshField{<:Tuple{CellField}})
+    println("plot2")
     uh = p[1]
     trian = Makie.lift(get_triangulation, uh)
     grid_and_data = Makie.lift(to_grid, trian, uh)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -31,7 +31,7 @@ end
 mesh_theme = Makie.Theme(
         color      = :pink,
         colormap   = :bluesreds,
-        shading    = false,
+        shading    = Makie.automatic,
         cycle      = nothing
 )
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -104,9 +104,9 @@ end
 function Makie.convert_arguments(::Type{<:Makie.Mesh}, trian::Triangulation)
     println("convert3")
     grid = to_grid(trian)
-    (PlotGrid(grid), )
-    #mesh = to_plot_mesh(grid)
-    #(mesh, )
+    #(PlotGrid(grid), )
+    mesh = to_plot_mesh(grid)
+    (mesh, )
 end
 
 function Makie.convert_arguments(t::Type{<:Union{Makie.Wireframe, Makie.Scatter}}, trian::Triangulation)
@@ -148,6 +148,7 @@ Makie.plottype(::Triangulation, ::Any) = MeshField
 function Makie.plot!(p::MeshField{<:Tuple{CellField}})
     println("plot2")
     uh = p[1]
+    println(typeof(uh))
     trian = Makie.lift(get_triangulation, uh)
     grid_and_data = Makie.lift(to_grid, trian, uh)
     pg = Makie.lift(i->PlotGrid(i[1]), grid_and_data)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -104,9 +104,9 @@ end
 function Makie.convert_arguments(::Type{<:Makie.Mesh}, trian::Triangulation)
     println("convert3")
     grid = to_grid(trian)
-     #(PlotGrid(grid), )
-    mesh = to_plot_mesh(grid)
-    (mesh, )
+    (PlotGrid(grid), )
+    #mesh = to_plot_mesh(grid)
+    #(mesh, )
 end
 
 function Makie.convert_arguments(t::Type{<:Union{Makie.Wireframe, Makie.Scatter}}, trian::Triangulation)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -89,7 +89,8 @@ end
 function Makie.convert_arguments(::Type{<:Makie.Wireframe}, pg::PlotGrid)
     grid = get_grid(pg)
     mesh = to_plot_mesh(grid)
-    (mesh, )
+    #(mesh, )
+    mesh
 end
 
 function Makie.convert_arguments(::Type{<:Makie.Scatter}, pg::PlotGrid)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -33,7 +33,7 @@ end
 mesh_theme = Makie.Theme(
         color      = :pink,
         colormap   = :bluesreds,
-        shading    = Makie.automatic,
+        shading    = nothing,
         cycle      = nothing
 )
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -7,6 +7,7 @@ Gridap.Geometry.get_grid(pg::PlotGrid) = pg.grid
 setup_color(color::Union{Symbol, Makie.Colorant}, ::Grid) = color
 
 function setup_color(color::AbstractArray, grid::Grid)
+    println("setup_color")
     color = if length(color) == num_nodes(grid)
                 to_dg_node_values(grid, color)
             elseif length(color) == num_cells(grid)
@@ -19,6 +20,7 @@ end
 setup_face_color(color::Union{Symbol, Makie.Colorant}, ::Grid, ::Any) = color
 
 function setup_face_color(color::AbstractArray, grid::Grid, face_to_cell)
+    println("setup_face_color")
     color = if length(color) == num_nodes(grid)
                 color
             elseif length(color) == num_cells(grid)
@@ -47,6 +49,7 @@ end
 
 # The lift function is necessary when dealing with reactive attributes or Observables.
 function Makie.plot!(plot::Makie.Mesh{<:Tuple{PlotGrid}})
+    println("plot!1")
     grid = Makie.lift(get_grid, plot[1])
     D = num_cell_dims(grid[])
     if D in (0,1,2)
@@ -172,5 +175,6 @@ Makie.plottype(::CellField) = MeshField
 
 
 function Makie.point_iterator(pg::PlotGrid)
+    println("point_terator")
     UnstructuredGrid(pg.grid) |> to_dg_points
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -33,7 +33,7 @@ end
 mesh_theme = Makie.Theme(
         color      = :pink,
         colormap   = :bluesreds,
-        shading    = nothing,
+        shading    = NoShading,
         cycle      = nothing
 )
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -132,12 +132,18 @@ end
 function Makie.plot!(p::MeshField{<:Tuple{Triangulation, Any}})
     println("plot1")
     trian, uh = p[1:2]
+    println(typeof(uh))
     grid_and_data = Makie.lift(to_grid, trian, uh)
+    println("1")
     pg = Makie.lift(i->PlotGrid(i[1]), grid_and_data)
+    println("2")
     p[:color] = Makie.lift(i->i[2], grid_and_data)
+    println("3")
     if p[:colorrange][] === Makie.automatic
+        println("4")
         p[:colorrange] = Makie.lift(extrema, p[:color])
     end
+    println("5")
     Makie.mesh!(p, pg;
         p.attributes.attributes...
     )

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -135,7 +135,8 @@ function Makie.plot!(p::MeshField{<:Tuple{Triangulation, Any}})
     println(typeof(uh))
     grid_and_data = Makie.lift(to_grid, trian, uh)
     println("1")
-    pg = Makie.lift(i->PlotGrid(i[1]), grid_and_data)
+    #pg = Makie.lift(i->PlotGrid(i[1]), grid_and_data)
+    mesh = Makie.lift(i->to_plot_mesh(i[1]), grid_and_data)
     println("2")
     p[:color] = Makie.lift(i->i[2], grid_and_data)
     println("3")
@@ -144,7 +145,7 @@ function Makie.plot!(p::MeshField{<:Tuple{Triangulation, Any}})
         p[:colorrange] = Makie.lift(extrema, p[:color])
     end
     println("5")
-    Makie.mesh!(p, pg;
+    Makie.mesh!(p, mesh;
         p.attributes.attributes...
     )
 end

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -33,7 +33,7 @@ end
 mesh_theme = Makie.Theme(
         color      = :pink,
         colormap   = :bluesreds,
-        shading    = NoShading,
+        shading    = Makie.NoShading,
         cycle      = nothing
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,33 +88,33 @@ end
     celldata = rand(num_cells(Ω))
 
     @test savefig("3d_Fig1") do
-        fig = plot(Ω)
+        fig = plot(Ω,axis=(type=Makie.Axis3,aspect=:data))
         wireframe!(Ω)
         scatter!(Ω)
         fig
     end
     @test savefig("3d_Fig11") do
-        fig, _ , sc = plot(Ω, uh, colorrange=(0,1))
+        fig, _ , sc = plot(Ω, uh, colorrange=(0,1),axis=(type=Makie.Axis3,aspect=:data))
         Colorbar(fig[1,2],sc)
         fig
     end
     @test savefig("3d_Fig111") do
-        fig, _ , sc = plot(Γ, uh, colormap=:algae)
+        fig, _ , sc = plot(Γ, uh, colormap=:algae,axis=(type=Makie.Axis3,aspect=:data))
         Colorbar(fig[1,2],sc)
         fig
     end
     @test savefig("3d_Fig12") do
-        fig = plot(Ω, color=:green)
+        fig = plot(Ω, color=:green,axis=(type=Makie.Axis3,aspect=:data))
         wireframe!(Ω, color=:red, linewidth=2.5)
         fig
     end
     @test savefig("3d_Fig13") do
-      fig, _ , plt = plot(Ω, color=3*celldata, colormap=:heat)
+      fig, _ , plt = plot(Ω, color=3*celldata, colormap=:heat,axis=(type=Makie.Axis3,aspect=:data))
         Colorbar(fig[1,2], plt)
         fig
     end
     @test savefig("3d_Fig14") do
-        fig, _ , plt = plot(Λ, jump(n_Λ⋅∇(uh)))
+        fig, _ , plt = plot(Λ, jump(n_Λ⋅∇(uh)),axis=(type=Makie.Axis3,aspect=:data))
         Colorbar(fig[1,2],plt)
         fig
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -88,38 +88,38 @@ end
     celldata = rand(num_cells(Ω))
 
     @test savefig("3d_Fig1") do
-        fig = plot(Ω,axis=(type=Makie.Axis3,aspect=:data))
+        fig = plot(Ω)
         wireframe!(Ω)
         scatter!(Ω)
         fig
     end
     @test savefig("3d_Fig11") do
-        fig, _ , sc = plot(Ω, uh, colorrange=(0,1),axis=(type=Makie.Axis3,aspect=:data))
+        fig, _ , sc = plot(Ω, uh, colorrange=(0,1))
         Colorbar(fig[1,2],sc)
         fig
     end
     @test savefig("3d_Fig111") do
-        fig, _ , sc = plot(Γ, uh, colormap=:algae,axis=(type=Makie.Axis3,aspect=:data))
+        fig, _ , sc = plot(Γ, uh, colormap=:algae)
         Colorbar(fig[1,2],sc)
         fig
     end
     @test savefig("3d_Fig12") do
-        fig = plot(Ω, color=:green,axis=(type=Makie.Axis3,aspect=:data))
+        fig = plot(Ω, color=:green)
         wireframe!(Ω, color=:red, linewidth=2.5)
         fig
     end
     @test savefig("3d_Fig13") do
-      fig, _ , plt = plot(Ω, color=3*celldata, colormap=:heat,axis=(type=Makie.Axis3,aspect=:data))
+        fig, _ , plt = plot(Ω, color=3*celldata, colormap=:heat)
         Colorbar(fig[1,2], plt)
         fig
     end
     @test savefig("3d_Fig14") do
-        fig, _ , plt = plot(Λ, jump(n_Λ⋅∇(uh)),axis=(type=Makie.Axis3,aspect=:data))
+        fig, _ , plt = plot(Λ, jump(n_Λ⋅∇(uh)))
         Colorbar(fig[1,2],plt)
         fig
     end
     @test savefig("3d_fig15") do 
-      fig, _ , plt = plot(uh, colormap=:Spectral, colorrange=(0,1))
+        fig, _ , plt = plot(uh, colormap=:Spectral, colorrange=(0,1))
         Colorbar(fig[1,2], plt)
         fig   
     end


### PR DESCRIPTION
I made some modifications to make GridapMakie compatible with Makie 0.21 (but not with previous versions).

There is only one small drawback: I do not understand how to change axis type for a full recipe and one must specify `axis=(type=Makie.Axis3,aspect=:data)` when plotting 3D data.