### PR TITLE
Add support to Makie 0.22 and GeometryBasics 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,10 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 [compat]
 FileIO = "1"
 FillArrays = "1"
-GLMakie = "0.10"
-GeometryBasics = "0.3, 0.4"
+GLMakie = "0.11"
+GeometryBasics = "0.5"
 Gridap = "0.16, 0.17,0.18"
-Makie = "0.21"
+Makie = "0.22"
 julia = "1.6"
 
 [extras]

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -35,7 +35,7 @@ function to_mesh(grid::UnstructuredGrid)
   Tc = eltype(eltype(cns))
   Dc = num_cell_dims(grid)
   fs = collect(lazy_map(GeometryBasics.NgonFace{Dc+1,Tc},cns))
-  GeometryBasics.Mesh(GeometryBasics.connect(ps,fs))
+  GeometryBasics.Mesh(ps,fs)
 end
 
 # Create discontinuous grid with the corresponding handling of nodal or cell fields.
@@ -64,7 +64,7 @@ function to_dg_mesh(grid::UnstructuredGrid)
     cns[cell] = cn
   end
   fs = lazy_map(GeometryBasics.NgonFace{Dc+1,Tc}, cns) |> collect
-  GeometryBasics.connect(ps, fs) |> GeometryBasics.Mesh
+  GeometryBasics.Mesh(ps,fs)
 end
 
 function to_dg_node_values(grid::Grid, node_value::Vector)


### PR DESCRIPTION
compat was updated to support the new version of Makie and GeometryBasics.

There are some breaking changes in GeometryBasics that required some small changes in conversions. 

@JordiManyer 