### PR TITLE
Support of Gridap v0.20

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated to support Gridap 0.20
 - Remove FileIO dependency
+- Raise Julia minimum compatibility to 1.10
 
 ## [0.1.7] - 2025-06-25
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2026-03-21
+
+### Added 
+
+- Updated to support Gridap 0.20
+- Remove FileIO dependency
+
 ## [0.1.7] - 2025-06-25
 
 ### Added 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridapMakie"
 uuid = "41f30b06-6382-4b60-a5f7-79d86b35bf5d"
 authors = ["Alberto F. Martín <alberto.f.martin@anu.edu.au>", "Eric Neiva <eneiva@cimne.upc.edu>", "Pau Riera <pau.riera.p@gmail.com>", "Francesc Verdugo <fverdugo@cimne.upc.edu>", "Jan Weidner <jw3126@gmail.com>", "Other contributors"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Alberto F. Martín <alberto.f.martin@anu.edu.au>", "Eric Neiva <enei
 version = "0.1.7"
 
 [deps]
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
@@ -12,7 +11,6 @@ Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [compat]
-FileIO = "1"
 FillArrays = "1"
 GLMakie = "0.13"
 GeometryBasics = "0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ GLMakie = "0.13"
 GeometryBasics = "0.5"
 Gridap = "0.16, 0.17, 0.18, 0.19"
 Makie = "0.24"
-julia = "1.6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 FillArrays = "1"
 GLMakie = "0.13"
 GeometryBasics = "0.5"
-Gridap = "0.16, 0.17, 0.18, 0.19"
+Gridap = "0.16, 0.17, 0.18, 0.19, 0.20"
 Makie = "0.24"
 julia = "1.10"
 

--- a/README.md
+++ b/README.md
@@ -28,22 +28,20 @@ A significant part of this package has been developed in the framework of the Go
 
 ## Installation
 
-According to Makie's guidelines, it is enough to install one of its backends, e.g. GLMakie. Additionally, Gridap provides the plot objects
-to be visualized and `FileIO` allows to save the figures plotted.
+According to Makie's guidelines, it is enough to install one of its backends, e.g. GLMakie.
 
 ```julia
 julia> ]
-pkg> add Gridap, GridapMakie, GLMakie, FileIO
+pkg> add Gridap, GridapMakie, GLMakie
 ```
 
 ## Examples
 
-First things first, we shall be using the three packages as well as `FileIO`.
+First things first, we shall be using the three packages.
 We may as well create directories to store downloaded meshes and output files
 
 ````julia
 using Gridap, GridapMakie, GLMakie
-using FileIO
 mkdir("models")
 mkdir("images")
 ````

--- a/README.md
+++ b/README.md
@@ -155,7 +155,11 @@ take the mesh from the [first Gridap tutorial](https://gridap.github.io/Tutorial
 which can be downloaded using
 
 ````julia
-url = "https://github.com/gridap/GridapMakie.jl/raw/d5d74190e68bd310483fead8a4154235a61815c5/_readme/model.json"
+if pkgversion(Gridap)<v"0.19.8"
+    url = "https://github.com/gridap/GridapMakie.jl/raw/d5d74190e68bd310483fead8a4154235a61815c5/_readme/model.json"
+else
+    url = "https://github.com/gridap/GridapMakie.jl/raw/d5d74190e68bd310483fead8a4154235a61815c5/_readme/model_0.16.json"
+end
 download(url,"models/model.json")
 ````
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(;
     repo="https://github.com/gridap/GridapMakie.jl/blob/{commit}{path}#L{line}",
     sitename="GridapMakie.jl",
     authors="The GridapMakie project contributors",
+    warnonly=true,
 )
 
 deploydocs(;

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -23,36 +23,12 @@ function setup_face_color(color::AbstractArray, grid::Grid, face_to_cell)
 end
 
 @Makie.recipe MeshField begin
-    linewidth = @inherit linewidth
-    linecap = @inherit linecap
-    joinstyle = @inherit joinstyle
-    linestyle = nothing
-    miter_limit = @inherit miter_limit
-    cycle      = nothing
-    uv_transform = Makie.automatic
-    matcap = nothing
-    marker = @inherit marker
-    markersize = @inherit markersize
-    strokecolor = @inherit markerstrokecolor
-    strokewidth = @inherit markerstrokewidth
-    glowcolor = (:black, 0.0)
-    glowwidth = 0.0
-    rotation = Makie.Billboard()
-    marker_offset = Makie.Vec3f(0)
-    font = @inherit markerfont
-    distancefield = nothing
-    interpolate = true
-    font = "default"
-    uv_offset_width = (0.0, 0.0, 0.0, 0.0)
-    markerspace = :pixel
-    depthsorting = false
-    Makie.mixin_generic_plot_attributes()...
-    Makie.mixin_colormap_attributes()...
-    Makie.mixin_shading_attributes()...
+    Makie.DocumentedAttributes(merge(Makie.documented_attributes(Makie.Mesh).d,Makie.documented_attributes(Makie.LineSegments).d,Makie.documented_attributes(Makie.Scatter).d))...
     fxaa = false
     shading    = Makie.NoShading
     colormap   = :bluesreds
     color = :pink
+    cycle      = nothing
 end
 
 Makie.plottype(::Triangulation{<:Any,1}) = Makie.Scatter
@@ -61,6 +37,11 @@ Makie.plottype(::Triangulation) = MeshField
 Makie.plottype(::Triangulation,::Any) = MeshField
 Makie.plottype(c::CellField) = Makie.plottype(get_triangulation(c),c)
 Makie.args_preferred_axis(::Triangulation{<:Any,Dp}) where Dp = Dp<=2 ? Makie.Axis : Makie.LScene
+
+function Makie.convert_arguments(::Type{<:Makie.Wireframe}, trian::Triangulation{<:Any,1})
+    x=to_point1D(trian)
+    return (x[1],x[2],zeros(length(x[1]),length(x[1])))
+end
 
 function Makie.convert_arguments(::Type{<:Makie.Wireframe}, trian::Triangulation)
     grid = to_grid(trian)
@@ -79,20 +60,15 @@ function Makie.convert_arguments(::Type{<:MeshField}, c::CellField)
     (get_triangulation(c), c)
 end
 
-function Makie.convert_arguments(::Union{Type{Makie.Lines},Type{Makie.ScatterLines},Type{Makie.Scatter}}, c::CellField)
-    trian=get_triangulation(c)
-    if num_point_dims(trian)==1
-        return to_point1D(trian, c)
-    else
-        @unreachable
-    end
+function Makie.convert_arguments(t::Union{Type{Makie.Lines},Type{Makie.ScatterLines},Type{Makie.Scatter}}, c::CellField)
+    Makie.convert_arguments(t,get_triangulation(c), c)
 end
 
-function Makie.convert_arguments(::Union{Type{Makie.Lines},Type{Makie.ScatterLines},Type{Makie.Scatter}}, trian::Triangulation{Dc,1}, uh::Any) where Dc
+function Makie.convert_arguments(::Union{Type{Makie.Lines},Type{Makie.ScatterLines},Type{Makie.Scatter}}, trian::Triangulation{<:Any,1}, uh::Any)
     return to_point1D(trian, uh)
 end
 
-function Makie.convert_arguments(::Union{Type{Makie.Lines},Type{Makie.ScatterLines},Type{Makie.Scatter}}, trian::Triangulation{Dc,1}) where Dc
+function Makie.convert_arguments(::Union{Type{Makie.Lines},Type{Makie.ScatterLines},Type{Makie.Scatter}}, trian::Triangulation{<:Any,1})
     return to_point1D(trian)
 end
 
@@ -190,11 +166,11 @@ function Makie.plot!(p::MeshField{<:Tuple{Triangulation{3,<:Any}}})
     Makie.mesh!(p, p.attributes, p.mesh,color=p.newcolor)
 end
 
-function Makie.plot!(p::MeshField{<:Tuple{Triangulation, Any}})
+function Makie.plot!(::MeshField{<:Tuple{Triangulation, Any}})
     @unreachable
 end
 
-function Makie.plot!(p::MeshField{<:Tuple{Triangulation}})
+function Makie.plot!(::MeshField{<:Tuple{Triangulation}})
     @unreachable
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,8 +5,6 @@ using Gridap
 using GLMakie
 using Test
 
-import FileIO
-
 const OUTDIR = joinpath(@__DIR__, "output")
 rm(OUTDIR, force=true, recursive=true)
 mkpath(OUTDIR)
@@ -17,7 +15,7 @@ function savefig(f, suffix::String)
     filename = "$(suffix).png"
     @show filename
     path = joinpath(OUTDIR, filename)
-    FileIO.save(path, fig)
+    save(path, fig)
     return true
 end
 


### PR DESCRIPTION
This is an update to support `Gridap` v0.20
I have also raised Julia minimum compatibility to 1.10 and removed the `FileIO` dependency.


